### PR TITLE
fix: Changing metric_transformation_value var type to string

### DIFF
--- a/modules/log-metric-filter/README.md
+++ b/modules/log-metric-filter/README.md
@@ -16,7 +16,7 @@
 | metric\_transformation\_default\_value | The value to emit when a filter pattern does not match a log event. | `string` | n/a | yes |
 | metric\_transformation\_name | The name of the CloudWatch metric to which the monitored log information should be published (e.g. ErrorCount) | `string` | n/a | yes |
 | metric\_transformation\_namespace | The destination namespace of the CloudWatch metric. | `string` | n/a | yes |
-| metric\_transformation\_value | What to publish to the metric. For example, if you're counting the occurrences of a particular term like 'Error', the value will be '1' for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event. | `number` | `1` | no |
+| metric\_transformation\_value | What to publish to the metric. For example, if you're counting the occurrences of a particular term like 'Error', the value will be '1' for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event. | `string` | `"1"` | no |
 | name | A name for the metric filter. | `string` | n/a | yes |
 | pattern | A valid CloudWatch Logs filter pattern for extracting metric data out of ingested log events. | `string` | n/a | yes |
 

--- a/modules/log-metric-filter/variables.tf
+++ b/modules/log-metric-filter/variables.tf
@@ -32,8 +32,8 @@ variable "metric_transformation_namespace" {
 
 variable "metric_transformation_value" {
   description = "What to publish to the metric. For example, if you're counting the occurrences of a particular term like 'Error', the value will be '1' for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event."
-  type        = number
-  default     = 1
+  type        = string
+  default     = "1"
 }
 
 variable "metric_transformation_default_value" {


### PR DESCRIPTION
## Description
Changes the log-metric-filter module to accept a string for the variable `metric_transformation_value`

## Motivation and Context
This is to make the module consistent with how the API behaves. If a user wants to define map the value of a metric to a specific value pulled from a CloudWatch log, a reference in the form of a string would need to be used (example: `$.loadAverageMinute.five`). An example of when you'd want a string is if you want to use this module to take Enhanced Metrics from RDS and put those values into a CloudWatch metric, so you want to map the value of something in the log to the value going into the metric.

Here's the AWS API reference for `metricValue` showing the type as string:

https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_MetricTransformation.html

The current AWS provider also supports a string for this value:

https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_cloudwatch_log_metric_filter.go#L71-L75


## Breaking Changes
This change is backward compatible. If a number is passed in as `1` for example instead of `"1"`, it will still work.

## How Has This Been Tested?
This has been tested as a fork. I tested setting the value to a string such as `$.loadAverageMinute.five`, to a number as a string `"1"`, and to a number directly `1`. All of these tests worked, which means this change would be backwards compatible.