### PR TITLE
feat: Added default value of 0 for metric filter for cis-alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- Added default value of 0 for metric filters
 
 <a name="v1.1.0"></a>
 ## [v1.1.0] - 2020-05-11

--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -95,9 +95,10 @@ resource "aws_cloudwatch_log_metric_filter" "this" {
   log_group_name = lookup(each.value, "log_group_name", var.log_group_name)
 
   metric_transformation {
-    name      = each.key
-    namespace = lookup(each.value, "namespace", var.namespace)
-    value     = 1
+    name          = each.key
+    namespace     = lookup(each.value, "namespace", var.namespace)
+    value         = 1
+    default_value = 0
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I have added default value of 0 to the metric filter when the event pattern do not match.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Metrics would not appear in cloudwatch metrics as there were no values for them

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed the CIS metrics filters onto my aws account. I was able to see the metrics of the filters that did not have data