### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/examples/cis-alarms/README.md
+++ b/examples/cis-alarms/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| all_cis_alarms | ../../modules/cis-alarms |  |
-| aws_sns_topic | ../fixtures/aws_sns_topic |  |
-| disabled_all_cis_alarms | ../../modules/cis-alarms |  |
-| log | ../fixtures/aws_cloudwatch_log_group |  |
+| <a name="module_all_cis_alarms"></a> [all\_cis\_alarms](#module\_all\_cis\_alarms) | ../../modules/cis-alarms |  |
+| <a name="module_aws_sns_topic"></a> [aws\_sns\_topic](#module\_aws\_sns\_topic) | ../fixtures/aws_sns_topic |  |
+| <a name="module_disabled_all_cis_alarms"></a> [disabled\_all\_cis\_alarms](#module\_disabled\_all\_cis\_alarms) | ../../modules/cis-alarms |  |
+| <a name="module_log"></a> [log](#module\_log) | ../fixtures/aws_cloudwatch_log_group |  |
 
 ## Resources
 
@@ -41,12 +41,12 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arns | List of ARNs of the Cloudwatch metric alarm |
-| this\_cloudwatch\_metric\_alarm\_ids | List of IDs of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_arns"></a> [this\_cloudwatch\_metric\_alarm\_arns](#output\_this\_cloudwatch\_metric\_alarm\_arns) | List of ARNs of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_ids"></a> [this\_cloudwatch\_metric\_alarm\_ids](#output\_this\_cloudwatch\_metric\_alarm\_ids) | List of IDs of the Cloudwatch metric alarm |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-log-metric-filter-and-alarm/README.md
+++ b/examples/complete-log-metric-filter-and-alarm/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alarm | ../../modules/metric-alarm |  |
-| aws_sns_topic | ../fixtures/aws_sns_topic |  |
-| log | ../fixtures/aws_cloudwatch_log_group |  |
-| log_metric_filter | ../../modules/log-metric-filter |  |
+| <a name="module_alarm"></a> [alarm](#module\_alarm) | ../../modules/metric-alarm |  |
+| <a name="module_aws_sns_topic"></a> [aws\_sns\_topic](#module\_aws\_sns\_topic) | ../fixtures/aws_sns_topic |  |
+| <a name="module_log"></a> [log](#module\_log) | ../fixtures/aws_cloudwatch_log_group |  |
+| <a name="module_log_metric_filter"></a> [log\_metric\_filter](#module\_log\_metric\_filter) | ../../modules/log-metric-filter |  |
 
 ## Resources
 
@@ -41,13 +41,13 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_log\_metric\_filter\_id | The name of the metric filter |
-| this\_cloudwatch\_metric\_alarm\_arn | The ARN of the Cloudwatch metric alarm |
-| this\_cloudwatch\_metric\_alarm\_id | The ID of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_log_metric_filter_id"></a> [this\_cloudwatch\_log\_metric\_filter\_id](#output\_this\_cloudwatch\_log\_metric\_filter\_id) | The name of the metric filter |
+| <a name="output_this_cloudwatch_metric_alarm_arn"></a> [this\_cloudwatch\_metric\_alarm\_arn](#output\_this\_cloudwatch\_metric\_alarm\_arn) | The ARN of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_id"></a> [this\_cloudwatch\_metric\_alarm\_id](#output\_this\_cloudwatch\_metric\_alarm\_id) | The ID of the Cloudwatch metric alarm |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/lambda-metric-alarm/README.md
+++ b/examples/lambda-metric-alarm/README.md
@@ -19,23 +19,23 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alarm | ../../modules/metric-alarm |  |
-| alarm_metric_query | ../../modules/metric-alarm |  |
-| all_lambdas_errors_alarm | ../../modules/metric-alarm |  |
-| aws_lambda_function1 | ../fixtures/aws_lambda_function |  |
-| aws_lambda_function2 | ../fixtures/aws_lambda_function |  |
-| aws_sns_topic | ../fixtures/aws_sns_topic |  |
+| <a name="module_alarm"></a> [alarm](#module\_alarm) | ../../modules/metric-alarm |  |
+| <a name="module_alarm_metric_query"></a> [alarm\_metric\_query](#module\_alarm\_metric\_query) | ../../modules/metric-alarm |  |
+| <a name="module_all_lambdas_errors_alarm"></a> [all\_lambdas\_errors\_alarm](#module\_all\_lambdas\_errors\_alarm) | ../../modules/metric-alarm |  |
+| <a name="module_aws_lambda_function1"></a> [aws\_lambda\_function1](#module\_aws\_lambda\_function1) | ../fixtures/aws_lambda_function |  |
+| <a name="module_aws_lambda_function2"></a> [aws\_lambda\_function2](#module\_aws\_lambda\_function2) | ../fixtures/aws_lambda_function |  |
+| <a name="module_aws_sns_topic"></a> [aws\_sns\_topic](#module\_aws\_sns\_topic) | ../fixtures/aws_sns_topic |  |
 
 ## Resources
 
@@ -43,14 +43,14 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arn | The ARN of the Cloudwatch metric alarm |
-| this\_cloudwatch\_metric\_alarm\_id | The ID of the Cloudwatch metric alarm |
-| this\_lambda\_function1\_arn | Lambda function ARN |
-| this\_lambda\_function1\_name | Lambda function name |
+| <a name="output_this_cloudwatch_metric_alarm_arn"></a> [this\_cloudwatch\_metric\_alarm\_arn](#output\_this\_cloudwatch\_metric\_alarm\_arn) | The ARN of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_id"></a> [this\_cloudwatch\_metric\_alarm\_id](#output\_this\_cloudwatch\_metric\_alarm\_id) | The ID of the Cloudwatch metric alarm |
+| <a name="output_this_lambda_function1_arn"></a> [this\_lambda\_function1\_arn](#output\_this\_lambda\_function1\_arn) | Lambda function ARN |
+| <a name="output_this_lambda_function1_name"></a> [this\_lambda\_function1\_name](#output\_this\_lambda\_function1\_name) | Lambda function name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-lambda-metric-alarm/README.md
+++ b/examples/multiple-lambda-metric-alarm/README.md
@@ -19,21 +19,21 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alarms | ../../modules/metric-alarms-by-multiple-dimensions |  |
-| aws_lambda_function1 | ../fixtures/aws_lambda_function |  |
-| aws_lambda_function2 | ../fixtures/aws_lambda_function |  |
-| aws_sns_topic | ../fixtures/aws_sns_topic |  |
+| <a name="module_alarms"></a> [alarms](#module\_alarms) | ../../modules/metric-alarms-by-multiple-dimensions |  |
+| <a name="module_aws_lambda_function1"></a> [aws\_lambda\_function1](#module\_aws\_lambda\_function1) | ../fixtures/aws_lambda_function |  |
+| <a name="module_aws_lambda_function2"></a> [aws\_lambda\_function2](#module\_aws\_lambda\_function2) | ../fixtures/aws_lambda_function |  |
+| <a name="module_aws_sns_topic"></a> [aws\_sns\_topic](#module\_aws\_sns\_topic) | ../fixtures/aws_sns_topic |  |
 
 ## Resources
 
@@ -41,14 +41,14 @@ No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arns | List of ARN of the Cloudwatch metric alarms |
-| this\_cloudwatch\_metric\_alarm\_ids | List of ID of the Cloudwatch metric alarms |
-| this\_lambda\_function1\_arn | Lambda function ARN |
-| this\_lambda\_function1\_name | Lambda function name |
+| <a name="output_this_cloudwatch_metric_alarm_arns"></a> [this\_cloudwatch\_metric\_alarm\_arns](#output\_this\_cloudwatch\_metric\_alarm\_arns) | List of ARN of the Cloudwatch metric alarms |
+| <a name="output_this_cloudwatch_metric_alarm_ids"></a> [this\_cloudwatch\_metric\_alarm\_ids](#output\_this\_cloudwatch\_metric\_alarm\_ids) | List of ID of the Cloudwatch metric alarms |
+| <a name="output_this_lambda_function1_arn"></a> [this\_lambda\_function1\_arn](#output\_this\_lambda\_function1\_arn) | Lambda function ARN |
+| <a name="output_this_lambda_function1_name"></a> [this\_lambda\_function1\_name](#output\_this\_lambda\_function1\_name) | Lambda function name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cis-alarms/README.md
+++ b/modules/cis-alarms/README.md
@@ -7,46 +7,46 @@ Read more about [CIS AWS Foundations Controls](https://docs.aws.amazon.com/secur
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
-| random | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_log_metric_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) |
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_metric_filter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| actions\_enabled | Indicates whether or not actions should be executed during any changes to the alarm's state. | `bool` | `true` | no |
-| alarm\_actions | List of ARNs to put as Cloudwatch Alarms actions (eg, ARN of SNS topic) | `list(string)` | `[]` | no |
-| create | Whether to create the Cloudwatch log metric filter and metric alarms | `bool` | `true` | no |
-| disabled\_controls | List of IDs of disabled CIS controls | `list(string)` | `[]` | no |
-| log\_group\_name | The name of the log group to associate the metric filter with | `string` | `""` | no |
-| namespace | The namespace where metric filter and metric alarm should be cleated | `string` | `"CISBenchmark"` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| use\_random\_name\_prefix | Whether to prefix resource names with random prefix | `bool` | `false` | no |
+| <a name="input_actions_enabled"></a> [actions\_enabled](#input\_actions\_enabled) | Indicates whether or not actions should be executed during any changes to the alarm's state. | `bool` | `true` | no |
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | List of ARNs to put as Cloudwatch Alarms actions (eg, ARN of SNS topic) | `list(string)` | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log metric filter and metric alarms | `bool` | `true` | no |
+| <a name="input_disabled_controls"></a> [disabled\_controls](#input\_disabled\_controls) | List of IDs of disabled CIS controls | `list(string)` | `[]` | no |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | The name of the log group to associate the metric filter with | `string` | `""` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace where metric filter and metric alarm should be cleated | `string` | `"CISBenchmark"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_use_random_name_prefix"></a> [use\_random\_name\_prefix](#input\_use\_random\_name\_prefix) | Whether to prefix resource names with random prefix | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arns | List of ARNs of the Cloudwatch metric alarm |
-| this\_cloudwatch\_metric\_alarm\_ids | List of IDs of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_arns"></a> [this\_cloudwatch\_metric\_alarm\_arns](#output\_this\_cloudwatch\_metric\_alarm\_arns) | List of ARNs of the Cloudwatch metric alarm |
+| <a name="output_this_cloudwatch_metric_alarm_ids"></a> [this\_cloudwatch\_metric\_alarm\_ids](#output\_this\_cloudwatch\_metric\_alarm\_ids) | List of IDs of the Cloudwatch metric alarm |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/log-metric-filter/README.md
+++ b/modules/log-metric-filter/README.md
@@ -5,41 +5,41 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_log_metric_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_metric_filter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_cloudwatch\_log\_metric\_filter | Whether to create the Cloudwatch log metric filter | `bool` | `true` | no |
-| log\_group\_name | The name of the log group to associate the metric filter with | `string` | n/a | yes |
-| metric\_transformation\_default\_value | The value to emit when a filter pattern does not match a log event. | `string` | `null` | no |
-| metric\_transformation\_name | The name of the CloudWatch metric to which the monitored log information should be published (e.g. ErrorCount) | `string` | n/a | yes |
-| metric\_transformation\_namespace | The destination namespace of the CloudWatch metric. | `string` | n/a | yes |
-| metric\_transformation\_value | What to publish to the metric. For example, if you're counting the occurrences of a particular term like 'Error', the value will be '1' for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event. | `string` | `"1"` | no |
-| name | A name for the metric filter. | `string` | n/a | yes |
-| pattern | A valid CloudWatch Logs filter pattern for extracting metric data out of ingested log events. | `string` | n/a | yes |
+| <a name="input_create_cloudwatch_log_metric_filter"></a> [create\_cloudwatch\_log\_metric\_filter](#input\_create\_cloudwatch\_log\_metric\_filter) | Whether to create the Cloudwatch log metric filter | `bool` | `true` | no |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | The name of the log group to associate the metric filter with | `string` | n/a | yes |
+| <a name="input_metric_transformation_default_value"></a> [metric\_transformation\_default\_value](#input\_metric\_transformation\_default\_value) | The value to emit when a filter pattern does not match a log event. | `string` | `null` | no |
+| <a name="input_metric_transformation_name"></a> [metric\_transformation\_name](#input\_metric\_transformation\_name) | The name of the CloudWatch metric to which the monitored log information should be published (e.g. ErrorCount) | `string` | n/a | yes |
+| <a name="input_metric_transformation_namespace"></a> [metric\_transformation\_namespace](#input\_metric\_transformation\_namespace) | The destination namespace of the CloudWatch metric. | `string` | n/a | yes |
+| <a name="input_metric_transformation_value"></a> [metric\_transformation\_value](#input\_metric\_transformation\_value) | What to publish to the metric. For example, if you're counting the occurrences of a particular term like 'Error', the value will be '1' for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event. | `string` | `"1"` | no |
+| <a name="input_name"></a> [name](#input\_name) | A name for the metric filter. | `string` | n/a | yes |
+| <a name="input_pattern"></a> [pattern](#input\_pattern) | A valid CloudWatch Logs filter pattern for extracting metric data out of ingested log events. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_log\_metric\_filter\_id | The name of the metric filter |
+| <a name="output_this_cloudwatch_log_metric_filter_id"></a> [this\_cloudwatch\_log\_metric\_filter\_id](#output\_this\_cloudwatch\_log\_metric\_filter\_id) | The name of the metric filter |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/metric-alarm/README.md
+++ b/modules/metric-alarm/README.md
@@ -5,56 +5,56 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| actions\_enabled | Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to true. | `bool` | `true` | no |
-| alarm\_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| alarm\_description | The description for the alarm. | `string` | `null` | no |
-| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account. | `string` | n/a | yes |
-| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
-| create\_metric\_alarm | Whether to create the Cloudwatch metric alarm | `bool` | `true` | no |
-| datapoints\_to\_alarm | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
-| dimensions | The dimensions for the alarm's associated metric. | `any` | `null` | no |
-| evaluate\_low\_sample\_count\_percentiles | Used only for alarms based on percentiles. If you specify ignore, the alarm state will not change during periods with too few data points to be statistically significant. If you specify evaluate or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available. The following values are supported: ignore, and evaluate. | `string` | `null` | no |
-| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
-| extended\_statistic | The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100. | `string` | `null` | no |
-| insufficient\_data\_actions | The list of actions to execute when this alarm transitions into an INSUFFICIENT\_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| metric\_name | The name for the alarm's associated metric. See docs for supported metrics. | `string` | `null` | no |
-| metric\_query | Enables you to create an alarm based on a metric math expression. You may specify at most 20. | `any` | `[]` | no |
-| namespace | The namespace for the alarm's associated metric. See docs for the list of namespaces. See docs for supported metrics. | `string` | `null` | no |
-| ok\_actions | The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| period | The period in seconds over which the specified statistic is applied. | `string` | `null` | no |
-| statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `null` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| threshold | The value against which the specified statistic is compared. | `number` | n/a | yes |
-| treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. | `string` | `"missing"` | no |
-| unit | The unit for the alarm's associated metric. | `string` | `null` | no |
+| <a name="input_actions_enabled"></a> [actions\_enabled](#input\_actions\_enabled) | Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to true. | `bool` | `true` | no |
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_alarm_description"></a> [alarm\_description](#input\_alarm\_description) | The description for the alarm. | `string` | `null` | no |
+| <a name="input_alarm_name"></a> [alarm\_name](#input\_alarm\_name) | The descriptive name for the alarm. This name must be unique within the user's AWS account. | `string` | n/a | yes |
+| <a name="input_comparison_operator"></a> [comparison\_operator](#input\_comparison\_operator) | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
+| <a name="input_create_metric_alarm"></a> [create\_metric\_alarm](#input\_create\_metric\_alarm) | Whether to create the Cloudwatch metric alarm | `bool` | `true` | no |
+| <a name="input_datapoints_to_alarm"></a> [datapoints\_to\_alarm](#input\_datapoints\_to\_alarm) | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
+| <a name="input_dimensions"></a> [dimensions](#input\_dimensions) | The dimensions for the alarm's associated metric. | `any` | `null` | no |
+| <a name="input_evaluate_low_sample_count_percentiles"></a> [evaluate\_low\_sample\_count\_percentiles](#input\_evaluate\_low\_sample\_count\_percentiles) | Used only for alarms based on percentiles. If you specify ignore, the alarm state will not change during periods with too few data points to be statistically significant. If you specify evaluate or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available. The following values are supported: ignore, and evaluate. | `string` | `null` | no |
+| <a name="input_evaluation_periods"></a> [evaluation\_periods](#input\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
+| <a name="input_extended_statistic"></a> [extended\_statistic](#input\_extended\_statistic) | The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100. | `string` | `null` | no |
+| <a name="input_insufficient_data_actions"></a> [insufficient\_data\_actions](#input\_insufficient\_data\_actions) | The list of actions to execute when this alarm transitions into an INSUFFICIENT\_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name for the alarm's associated metric. See docs for supported metrics. | `string` | `null` | no |
+| <a name="input_metric_query"></a> [metric\_query](#input\_metric\_query) | Enables you to create an alarm based on a metric math expression. You may specify at most 20. | `any` | `[]` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace for the alarm's associated metric. See docs for the list of namespaces. See docs for supported metrics. | `string` | `null` | no |
+| <a name="input_ok_actions"></a> [ok\_actions](#input\_ok\_actions) | The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_period"></a> [period](#input\_period) | The period in seconds over which the specified statistic is applied. | `string` | `null` | no |
+| <a name="input_statistic"></a> [statistic](#input\_statistic) | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_threshold"></a> [threshold](#input\_threshold) | The value against which the specified statistic is compared. | `number` | n/a | yes |
+| <a name="input_treat_missing_data"></a> [treat\_missing\_data](#input\_treat\_missing\_data) | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. | `string` | `"missing"` | no |
+| <a name="input_unit"></a> [unit](#input\_unit) | The unit for the alarm's associated metric. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arn | The ARN of the Cloudwatch metric alarm. |
-| this\_cloudwatch\_metric\_alarm\_id | The ID of the Cloudwatch metric alarm. |
+| <a name="output_this_cloudwatch_metric_alarm_arn"></a> [this\_cloudwatch\_metric\_alarm\_arn](#output\_this\_cloudwatch\_metric\_alarm\_arn) | The ARN of the Cloudwatch metric alarm. |
+| <a name="output_this_cloudwatch_metric_alarm_id"></a> [this\_cloudwatch\_metric\_alarm\_id](#output\_this\_cloudwatch\_metric\_alarm\_id) | The ID of the Cloudwatch metric alarm. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/metric-alarms-by-multiple-dimensions/README.md
+++ b/modules/metric-alarms-by-multiple-dimensions/README.md
@@ -5,56 +5,56 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.55 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| actions\_enabled | Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to true. | `bool` | `true` | no |
-| alarm\_actions | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| alarm\_description | The description for the alarm. | `string` | `null` | no |
-| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account. | `string` | n/a | yes |
-| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
-| create\_metric\_alarm | Whether to create the Cloudwatch metric alarm | `bool` | `true` | no |
-| datapoints\_to\_alarm | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
-| dimensions | The dimensions for the alarm's associated metric. | `any` | `null` | no |
-| evaluate\_low\_sample\_count\_percentiles | Used only for alarms based on percentiles. If you specify ignore, the alarm state will not change during periods with too few data points to be statistically significant. If you specify evaluate or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available. The following values are supported: ignore, and evaluate. | `string` | `null` | no |
-| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
-| extended\_statistic | The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100. | `string` | `null` | no |
-| insufficient\_data\_actions | The list of actions to execute when this alarm transitions into an INSUFFICIENT\_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| metric\_name | The name for the alarm's associated metric. See docs for supported metrics. | `string` | `null` | no |
-| metric\_query | Enables you to create an alarm based on a metric math expression. You may specify at most 20. | `any` | `[]` | no |
-| namespace | The namespace for the alarm's associated metric. See docs for the list of namespaces. See docs for supported metrics. | `string` | `null` | no |
-| ok\_actions | The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
-| period | The period in seconds over which the specified statistic is applied. | `string` | `null` | no |
-| statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `null` | no |
-| tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| threshold | The value against which the specified statistic is compared. | `number` | n/a | yes |
-| treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. | `string` | `"missing"` | no |
-| unit | The unit for the alarm's associated metric. | `string` | `null` | no |
+| <a name="input_actions_enabled"></a> [actions\_enabled](#input\_actions\_enabled) | Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to true. | `bool` | `true` | no |
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_alarm_description"></a> [alarm\_description](#input\_alarm\_description) | The description for the alarm. | `string` | `null` | no |
+| <a name="input_alarm_name"></a> [alarm\_name](#input\_alarm\_name) | The descriptive name for the alarm. This name must be unique within the user's AWS account. | `string` | n/a | yes |
+| <a name="input_comparison_operator"></a> [comparison\_operator](#input\_comparison\_operator) | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
+| <a name="input_create_metric_alarm"></a> [create\_metric\_alarm](#input\_create\_metric\_alarm) | Whether to create the Cloudwatch metric alarm | `bool` | `true` | no |
+| <a name="input_datapoints_to_alarm"></a> [datapoints\_to\_alarm](#input\_datapoints\_to\_alarm) | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
+| <a name="input_dimensions"></a> [dimensions](#input\_dimensions) | The dimensions for the alarm's associated metric. | `any` | `null` | no |
+| <a name="input_evaluate_low_sample_count_percentiles"></a> [evaluate\_low\_sample\_count\_percentiles](#input\_evaluate\_low\_sample\_count\_percentiles) | Used only for alarms based on percentiles. If you specify ignore, the alarm state will not change during periods with too few data points to be statistically significant. If you specify evaluate or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available. The following values are supported: ignore, and evaluate. | `string` | `null` | no |
+| <a name="input_evaluation_periods"></a> [evaluation\_periods](#input\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
+| <a name="input_extended_statistic"></a> [extended\_statistic](#input\_extended\_statistic) | The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100. | `string` | `null` | no |
+| <a name="input_insufficient_data_actions"></a> [insufficient\_data\_actions](#input\_insufficient\_data\_actions) | The list of actions to execute when this alarm transitions into an INSUFFICIENT\_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name for the alarm's associated metric. See docs for supported metrics. | `string` | `null` | no |
+| <a name="input_metric_query"></a> [metric\_query](#input\_metric\_query) | Enables you to create an alarm based on a metric math expression. You may specify at most 20. | `any` | `[]` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace for the alarm's associated metric. See docs for the list of namespaces. See docs for supported metrics. | `string` | `null` | no |
+| <a name="input_ok_actions"></a> [ok\_actions](#input\_ok\_actions) | The list of actions to execute when this alarm transitions into an OK state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
+| <a name="input_period"></a> [period](#input\_period) | The period in seconds over which the specified statistic is applied. | `string` | `null` | no |
+| <a name="input_statistic"></a> [statistic](#input\_statistic) | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
+| <a name="input_threshold"></a> [threshold](#input\_threshold) | The value against which the specified statistic is compared. | `number` | n/a | yes |
+| <a name="input_treat_missing_data"></a> [treat\_missing\_data](#input\_treat\_missing\_data) | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. | `string` | `"missing"` | no |
+| <a name="input_unit"></a> [unit](#input\_unit) | The unit for the alarm's associated metric. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_cloudwatch\_metric\_alarm\_arns | List of ARN of the Cloudwatch metric alarms |
-| this\_cloudwatch\_metric\_alarm\_ids | List of ID of the Cloudwatch metric alarms |
+| <a name="output_this_cloudwatch_metric_alarm_arns"></a> [this\_cloudwatch\_metric\_alarm\_arns](#output\_this\_cloudwatch\_metric\_alarm\_arns) | List of ARN of the Cloudwatch metric alarms |
+| <a name="output_this_cloudwatch_metric_alarm_ids"></a> [this\_cloudwatch\_metric\_alarm\_ids](#output\_this\_cloudwatch\_metric\_alarm\_ids) | List of ID of the Cloudwatch metric alarms |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
