### PR TITLE
feat: Added support for custom CIS alarm names

### DIFF
--- a/modules/cis-alarms/README.md
+++ b/modules/cis-alarms/README.md
@@ -39,6 +39,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log metric filter and metric alarms | `bool` | `true` | no |
 | <a name="input_disabled_controls"></a> [disabled\_controls](#input\_disabled\_controls) | List of IDs of disabled CIS controls | `list(string)` | `[]` | no |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | The name of the log group to associate the metric filter with | `string` | `""` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name prefix for the cloudwatch alarm, if use\_random\_name\_prefix is true, this will be ignored) | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace where metric filter and metric alarm should be cleated | `string` | `"CISBenchmark"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_random_name_prefix"></a> [use\_random\_name\_prefix](#input\_use\_random\_name\_prefix) | Whether to prefix resource names with random prefix | `bool` | `false` | no |

--- a/modules/cis-alarms/README.md
+++ b/modules/cis-alarms/README.md
@@ -39,7 +39,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log metric filter and metric alarms | `bool` | `true` | no |
 | <a name="input_disabled_controls"></a> [disabled\_controls](#input\_disabled\_controls) | List of IDs of disabled CIS controls | `list(string)` | `[]` | no |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | The name of the log group to associate the metric filter with | `string` | `""` | no |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name prefix for the cloudwatch alarm, if use\_random\_name\_prefix is true, this will be ignored) | `string` | `""` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name prefix for the cloudwatch alarm (if use\_random\_name\_prefix is true, this will be ignored) | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace where metric filter and metric alarm should be cleated | `string` | `"CISBenchmark"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_random_name_prefix"></a> [use\_random\_name\_prefix](#input\_use\_random\_name\_prefix) | Whether to prefix resource names with random prefix | `bool` | `false` | no |

--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -78,7 +78,7 @@ locals {
 
   ###############
 
-  prefix   = var.use_random_name_prefix ? "${random_pet.this[0].id}-" : length(var.name_prefix) > 0 ? var.name_prefix : ""
+  prefix   = var.use_random_name_prefix ? "${random_pet.this[0].id}-" : var.name_prefix
   controls = { for k, v in local.all_controls : k => v if !contains(var.disabled_controls, k) }
 }
 

--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -78,7 +78,7 @@ locals {
 
   ###############
 
-  prefix   = var.use_random_name_prefix ? "${random_pet.this[0].id}-" : ""
+  prefix   = var.use_random_name_prefix ? "${random_pet.this[0].id}-" : length(var.name_prefix) > 0 ? var.name_prefix : ""
   controls = { for k, v in local.all_controls : k => v if !contains(var.disabled_controls, k) }
 }
 

--- a/modules/cis-alarms/variables.tf
+++ b/modules/cis-alarms/variables.tf
@@ -11,7 +11,7 @@ variable "use_random_name_prefix" {
 }
 
 variable "name_prefix" {
-  description = "A name prefix for the cloudwatch alarm, if use_random_name_prefix is true, this will be ignored)"
+  description = "A name prefix for the cloudwatch alarm (if use_random_name_prefix is true, this will be ignored)"
   type        = string
   default     = ""
 }

--- a/modules/cis-alarms/variables.tf
+++ b/modules/cis-alarms/variables.tf
@@ -10,6 +10,12 @@ variable "use_random_name_prefix" {
   default     = false
 }
 
+variable "name_prefix" {
+  description = "A name prefix for the cloudwatch alarm, if use_random_name_prefix is true, this will be ignored)"
+  type        = string
+  default     = ""
+}
+
 variable "disabled_controls" {
   description = "List of IDs of disabled CIS controls"
   type        = list(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds variable to allow user customisation of prefix for alarms

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FIxes #28 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
