### PR TITLE
fix: Added prefix to metric name for alarm to work

### DIFF
--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -96,7 +96,7 @@ resource "aws_cloudwatch_log_metric_filter" "this" {
   log_group_name = lookup(each.value, "log_group_name", var.log_group_name)
 
   metric_transformation {
-    name          = each.key
+    name          = "${local.prefix}${each.key}"
     namespace     = lookup(each.value, "namespace", var.namespace)
     value         = 1
     default_value = 0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

CIS Alarms not triggered due to wrong metric name

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #31 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
