### PR TITLE
feat: Added account_id to metric_query section

### DIFF
--- a/modules/metric-alarm/main.tf
+++ b/modules/metric-alarm/main.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
     for_each = var.metric_query
     content {
       id          = lookup(metric_query.value, "id")
+      account_id  = lookup(metric_query.value, "account_id", null)
       label       = lookup(metric_query.value, "label", null)
       return_data = lookup(metric_query.value, "return_data", null)
       expression  = lookup(metric_query.value, "expression", null)


### PR DESCRIPTION
## Description
Just added the line which allows to use account_id for metric_querys. Please refer to the terraform resource for the provider support.

## Motivation and Context
Hope to fix https://github.com/terraform-aws-modules/terraform-aws-cloudwatch/issues/24

## Breaking Changes
Should not break anything.

## How Has This Been Tested?
- Created a local feature branch adding the parameter in the module.
- Rolled that out in my customers environment.
- Resource has been created as expected and supported by the terraform resource.
