### PR TITLE
fix: Update required version for aws provider

### DIFF
--- a/modules/metric-alarm/README.md
+++ b/modules/metric-alarm/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.54 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.54 |
 
 ## Modules
 

--- a/modules/metric-alarm/versions.tf
+++ b/modules/metric-alarm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.55"
+      version = ">= 3.54"
     }
   }
 }


### PR DESCRIPTION
fix: Update required version for aws provisioner to support account_d parameter on cloudwatch alarms

## Description
Fixes the missing provider updated introduced by the feature of PR https://github.com/terraform-aws-modules/terraform-aws-cloudwatch/pull/33

## Motivation and Context
Was simply overlooked during development and initial review but should be fixed.

## Breaking Changes
I have not been using the 2.x version of the aws provider for some time. I have not seen anything breaking in the CHANGELOG regarding cloudwatch.

## How Has This Been Tested?
- See feature request related to PR https://github.com/terraform-aws-modules/terraform-aws-cloudwatch/pull/33 . During the execution a newer version of the provider was already in use (3.64.0)