### PR TITLE
Update main.tf

### DIFF
--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -1,7 +1,7 @@
 locals {
   all_controls = {
     UnauthorizedAPICalls = {
-      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) && (($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") && ($.eventName!=\"HeadBucket\")) }"
+      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) }"
       description = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
     }
 


### PR DESCRIPTION
-UnauthorizedAPICalls only needs {($.errorCode="*UnauthorizedOperation") || ($.errorCode="AccessDenied*")} or else it fails in securityhub

## Description
Change UnauthorizedAPICalls

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In security hub UnauthorizedAPICalls fails as the pattern is different

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I have manually updated the pattern on in my loggroup and it seems to be working
