### PR TITLE
feat: Added anomaly detection support

### DIFF
--- a/examples/lambda-metric-alarm/README.md
+++ b/examples/lambda-metric-alarm/README.md
@@ -31,6 +31,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alarm"></a> [alarm](#module\_alarm) | ../../modules/metric-alarm | n/a |
+| <a name="module_alarm_anomaly"></a> [alarm\_anomaly](#module\_alarm\_anomaly) | ../../modules/metric-alarm | n/a |
 | <a name="module_alarm_metric_query"></a> [alarm\_metric\_query](#module\_alarm\_metric\_query) | ../../modules/metric-alarm | n/a |
 | <a name="module_all_lambdas_errors_alarm"></a> [all\_lambdas\_errors\_alarm](#module\_all\_lambdas\_errors\_alarm) | ../../modules/metric-alarm | n/a |
 | <a name="module_aws_lambda_function1"></a> [aws\_lambda\_function1](#module\_aws\_lambda\_function1) | ../fixtures/aws_lambda_function | n/a |

--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -106,3 +106,50 @@ module "alarm_metric_query" {
     Secure = "maybe"
   }
 }
+
+module "alarm_anomaly" {
+  source = "../../modules/metric-alarm"
+
+  alarm_name          = "lambda-invocations-anomaly-${module.aws_lambda_function2.random_id}"
+  alarm_description   = "Lambda invocations anomaly"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold_metric_id = "ad1"
+
+  metric_query = [{
+      id = "ad1"
+
+      return_data = true
+      expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+      label       = "Invocations (expected)"
+      return_data = "true"
+    },
+    {
+      id = "m1"
+
+      metric = [{
+        namespace   = "AWS/Lambda"
+        metric_name = "Invocations"
+        period      = 60
+        stat        = "Sum"
+        unit        = "Count"
+
+        dimensions = {
+          FunctionName = module.aws_lambda_function2.lambda_function_name
+        }
+      }]
+  }]
+
+  alarm_actions = [module.aws_sns_topic.sns_topic_arn]
+
+  tags = {
+    Secure = "maybe"
+  }
+}
+
+metric_query {
+    id          = "ad1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "Delivery (expected)"
+    return_data = "true"
+  }

--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -146,10 +146,3 @@ module "alarm_anomaly" {
     Secure = "maybe"
   }
 }
-
-metric_query {
-    id          = "ad1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-    label       = "Delivery (expected)"
-    return_data = "true"
-  }

--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -138,6 +138,7 @@ module "alarm_anomaly" {
           FunctionName = module.aws_lambda_function2.lambda_function_name
         }
       }]
+      return_data = "true"
   }]
 
   alarm_actions = [module.aws_sns_topic.sns_topic_arn]

--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -112,7 +112,7 @@ module "alarm_anomaly" {
 
   alarm_name          = "lambda-invocations-anomaly-${module.aws_lambda_function2.random_id}"
   alarm_description   = "Lambda invocations anomaly"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = 1
   threshold_metric_id = "ad1"
 

--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -117,12 +117,12 @@ module "alarm_anomaly" {
   threshold_metric_id = "ad1"
 
   metric_query = [{
-      id = "ad1"
+    id = "ad1"
 
-      return_data = true
-      expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-      label       = "Invocations (expected)"
-      return_data = "true"
+    return_data = true
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "Invocations (expected)"
+    return_data = "true"
     },
     {
       id = "m1"

--- a/modules/metric-alarm/README.md
+++ b/modules/metric-alarm/README.md
@@ -47,7 +47,8 @@ No modules.
 | <a name="input_period"></a> [period](#input\_period) | The period in seconds over which the specified statistic is applied. | `string` | `null` | no |
 | <a name="input_statistic"></a> [statistic](#input\_statistic) | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| <a name="input_threshold"></a> [threshold](#input\_threshold) | The value against which the specified statistic is compared. | `number` | n/a | yes |
+| <a name="input_threshold"></a> [threshold](#input\_threshold) | The value against which the specified statistic is compared. | `number` | `null` | no |
+| <a name="input_threshold_metric_id"></a> [threshold\_metric\_id](#input\_threshold\_metric\_id) | If this is an alarm based on an anomaly detection model, make this value match the ID of the ANOMALY\_DETECTION\_BAND function. | `string` | `null` | no |
 | <a name="input_treat_missing_data"></a> [treat\_missing\_data](#input\_treat\_missing\_data) | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. | `string` | `"missing"` | no |
 | <a name="input_unit"></a> [unit](#input\_unit) | The unit for the alarm's associated metric. | `string` | `null` | no |
 

--- a/modules/metric-alarm/main.tf
+++ b/modules/metric-alarm/main.tf
@@ -50,6 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
       }
     }
   }
+  threshold_metric_id = var.threshold_metric_id
 
   tags = var.tags
 }

--- a/modules/metric-alarm/variables.tf
+++ b/modules/metric-alarm/variables.tf
@@ -28,6 +28,7 @@ variable "evaluation_periods" {
 variable "threshold" {
   description = "The value against which the specified statistic is compared."
   type        = number
+  default     = null
 }
 
 variable "threshold_metric_id" {

--- a/modules/metric-alarm/variables.tf
+++ b/modules/metric-alarm/variables.tf
@@ -30,6 +30,12 @@ variable "threshold" {
   type        = number
 }
 
+variable "threshold_metric_id" {
+  description = "If this is an alarm based on an anomaly detection model, make this value match the ID of the ANOMALY_DETECTION_BAND function."
+  type        = string
+  default     = null
+}
+
 variable "unit" {
   description = "The unit for the alarm's associated metric."
   type        = string


### PR DESCRIPTION
## Description
Closes #13
Added `threshold_metric_id`  argument to `metric-alarm` module in order to support the creation of anomaly detection alarms. Make `threshold` variable optional as it should not be used for anomaly detection models. Added anomaly detection example.

## Motivation and Context
It is not possible to define alert with an anomaly detection model. See [#13](https://github.com/terraform-aws-modules/terraform-aws-cloudwatch/issues/13) for details.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have tested and validated changes on my existing alerts

I've run apply in examples/lambda-metric-alarm directory including new anomaly detection alert.
To confirm there are no breaking changes I've also changed the source of my existing alerts to the forked repository and run init and apply, as expected there were no changes reported by terraform.
