### PR TITLE
feat: Attaches log group resource policies

### DIFF
--- a/examples/log-group/README.md
+++ b/examples/log-group/README.md
@@ -1,0 +1,60 @@
+# Cloudwatch log group example
+
+Creates a Cloudwatch log group granting access to ElasticSearch.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.55 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.55 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_advanced_example"></a> [advanced\_example](#module\_advanced\_example) | ../../modules/log-group | n/a |
+| <a name="module_basic_example"></a> [basic\_example](#module\_basic\_example) | ../../modules/log-group | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_advanced_example_cloudwatch_log_group_arn"></a> [advanced\_example\_cloudwatch\_log\_group\_arn](#output\_advanced\_example\_cloudwatch\_log\_group\_arn) | ARN of Cloudwatch log group |
+| <a name="output_advanced_example_cloudwatch_log_group_name"></a> [advanced\_example\_cloudwatch\_log\_group\_name](#output\_advanced\_example\_cloudwatch\_log\_group\_name) | Name of Cloudwatch log group |
+| <a name="output_advanced_example_cloudwatch_log_group_resource_policies"></a> [advanced\_example\_cloudwatch\_log\_group\_resource\_policies](#output\_advanced\_example\_cloudwatch\_log\_group\_resource\_policies) | IDs of Cloudwatch Resource Policies |
+| <a name="output_basic_example_cloudwatch_log_group_arn"></a> [basic\_example\_cloudwatch\_log\_group\_arn](#output\_basic\_example\_cloudwatch\_log\_group\_arn) | ARN of Cloudwatch log group |
+| <a name="output_basic_example_cloudwatch_log_group_name"></a> [basic\_example\_cloudwatch\_log\_group\_name](#output\_basic\_example\_cloudwatch\_log\_group\_name) | Name of Cloudwatch log group |
+| <a name="output_basic_example_cloudwatch_log_group_resource_policies"></a> [basic\_example\_cloudwatch\_log\_group\_resource\_policies](#output\_basic\_example\_cloudwatch\_log\_group\_resource\_policies) | IDs of Cloudwatch Resource Policies |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/log-group/main.tf
+++ b/examples/log-group/main.tf
@@ -19,7 +19,7 @@ module "advanced_example" {
   resource_policies = {
     custom = data.aws_iam_policy_document.custom.json
   }
-  allowed_services = ["es", "lambda"]
+  allowed_service_ids = ["es", "lambda"]
 }
 
 data "aws_iam_policy_document" "custom" {

--- a/examples/log-group/main.tf
+++ b/examples/log-group/main.tf
@@ -1,0 +1,38 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+module "basic_example" {
+  source = "../../modules/log-group"
+
+  name = "basic-example"
+}
+
+module "advanced_example" {
+  source = "../../modules/log-group"
+
+  name = "example-with-policy"
+
+  resource_policies = {
+    custom = data.aws_iam_policy_document.custom.json
+  }
+  allowed_services = ["es", "lambda"]
+}
+
+data "aws_iam_policy_document" "custom" {
+  statement {
+    sid = "AllowElasticSearchLogs"
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+    ]
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:example-with-policy/*"]
+  }
+}

--- a/examples/log-group/outputs.tf
+++ b/examples/log-group/outputs.tf
@@ -1,0 +1,29 @@
+output "basic_example_cloudwatch_log_group_name" {
+  description = "Name of Cloudwatch log group"
+  value       = module.basic_example.cloudwatch_log_group_name
+}
+
+output "basic_example_cloudwatch_log_group_arn" {
+  description = "ARN of Cloudwatch log group"
+  value       = module.basic_example.cloudwatch_log_group_arn
+}
+
+output "basic_example_cloudwatch_log_group_resource_policies" {
+  description = "IDs of Cloudwatch Resource Policies"
+  value       = module.basic_example.cloudwatch_log_group_resource_policies
+}
+
+output "advanced_example_cloudwatch_log_group_name" {
+  description = "Name of Cloudwatch log group"
+  value       = module.advanced_example.cloudwatch_log_group_name
+}
+
+output "advanced_example_cloudwatch_log_group_arn" {
+  description = "ARN of Cloudwatch log group"
+  value       = module.advanced_example.cloudwatch_log_group_arn
+}
+
+output "advanced_example_cloudwatch_log_group_resource_policies" {
+  description = "IDs of Cloudwatch Resource Policies"
+  value       = module.advanced_example.cloudwatch_log_group_resource_policies
+}

--- a/examples/log-group/versions.tf
+++ b/examples/log-group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.55"
+    }
+  }
+}

--- a/modules/log-group/README.md
+++ b/modules/log-group/README.md
@@ -23,6 +23,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
 
 ## Inputs
 
@@ -32,6 +33,7 @@ No modules.
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting logs | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name for the log group | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name prefix for the log group | `string` | `null` | no |
+| <a name="input_resource_policies"></a> [resource\_policies](#input\_resource\_policies) | The resource policies to attach to the Cloudwatch log group mapped name to document | `map(string)` | `{}` | no |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group | `number` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to Cloudwatch log group | `map(string)` | `{}` | no |
 
@@ -41,4 +43,5 @@ No modules.
 |------|-------------|
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of Cloudwatch log group |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of Cloudwatch log group |
+| <a name="output_cloudwatch_log_group_resource_policy_ids"></a> [cloudwatch\_log\_group\_resource\_policy\_ids](#output\_cloudwatch\_log\_group\_resource\_policy\_ids) | IDs of Cloudwatch Resource Policies |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/log-group/README.md
+++ b/modules/log-group/README.md
@@ -30,6 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_service_actions"></a> [allowed\_service\_actions](#input\_allowed\_service\_actions) | The IAM actions to allow each service to perform | `list(string)` | <pre>[<br>  "logs:CreateLogStream",<br>  "logs:PutLogEvents",<br>  "logs:PutLogEventsBatch"<br>]</pre> | no |
 | <a name="input_allowed_services"></a> [allowed\_services](#input\_allowed\_services) | The names of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier | `set(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log group | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting logs | `string` | `null` | no |

--- a/modules/log-group/README.md
+++ b/modules/log-group/README.md
@@ -24,11 +24,13 @@ No modules.
 |------|------|
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_iam_policy_document.allowed_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_services"></a> [allowed\_services](#input\_allowed\_services) | The names of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier | `set(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log group | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting logs | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name for the log group | `string` | `null` | no |
@@ -43,5 +45,5 @@ No modules.
 |------|-------------|
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of Cloudwatch log group |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of Cloudwatch log group |
-| <a name="output_cloudwatch_log_group_resource_policy_ids"></a> [cloudwatch\_log\_group\_resource\_policy\_ids](#output\_cloudwatch\_log\_group\_resource\_policy\_ids) | IDs of Cloudwatch Resource Policies |
+| <a name="output_cloudwatch_log_group_resource_policies"></a> [cloudwatch\_log\_group\_resource\_policies](#output\_cloudwatch\_log\_group\_resource\_policies) | IDs of Cloudwatch Resource Policies |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/log-group/README.md
+++ b/modules/log-group/README.md
@@ -31,7 +31,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_service_actions"></a> [allowed\_service\_actions](#input\_allowed\_service\_actions) | The IAM actions to allow each service to perform | `list(string)` | <pre>[<br>  "logs:CreateLogStream",<br>  "logs:PutLogEvents",<br>  "logs:PutLogEventsBatch"<br>]</pre> | no |
-| <a name="input_allowed_services"></a> [allowed\_services](#input\_allowed\_services) | The names of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier | `set(string)` | `[]` | no |
+| <a name="input_allowed_service_ids"></a> [allowed\_service\_ids](#input\_allowed\_service\_ids) | The IDs of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier | `set(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log group | `bool` | `true` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting logs | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name for the log group | `string` | `null` | no |

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -8,3 +8,10 @@ resource "aws_cloudwatch_log_group" "this" {
 
   tags = var.tags
 }
+
+resource "aws_cloudwatch_log_resource_policy" "this" {
+  for_each = var.create ? var.resource_policies : {}
+
+  policy_name     = each.key
+  policy_document = each.value
+}

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -1,6 +1,6 @@
 locals {
   resource_policies = merge(var.resource_policies, {
-    for index, service in var.allowed_services :
+    for index, service in var.allowed_service_ids :
     service => data.aws_iam_policy_document.allowed_services[index].json
   })
 }
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_log_resource_policy" "this" {
 }
 
 data "aws_iam_policy_document" "allowed_services" {
-  for_each = var.allowed_services
+  for_each = var.allowed_service_ids
 
   statement {
     principals {

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -31,11 +31,7 @@ data "aws_iam_policy_document" "allowed_services" {
       type        = "Service"
       identifiers = ["${each.value}.amazonaws.com"]
     }
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:PutLogEventsBatch",
-    ]
+    actions   = var.allowed_service_actions
     resources = ["${join("", aws_cloudwatch_log_group.this.*.arn)}/*"]
   }
 }

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -32,8 +32,9 @@ data "aws_iam_policy_document" "allowed_services" {
       identifiers = ["${each.value}.amazonaws.com"]
     }
     actions = [
-      "logs:PutLogEvents",
       "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
     ]
     resources = ["${join("", aws_cloudwatch_log_group.this.*.arn)}/*"]
   }

--- a/modules/log-group/outputs.tf
+++ b/modules/log-group/outputs.tf
@@ -8,7 +8,7 @@ output "cloudwatch_log_group_arn" {
   value       = element(concat(aws_cloudwatch_log_group.this.*.arn, [""]), 0)
 }
 
-output "cloudwatch_log_group_resource_policy_ids" {
+output "cloudwatch_log_group_resource_policies" {
   description = "IDs of Cloudwatch Resource Policies"
-  value       = { for name, policy in aws_cloudwatch_log_resource_policy.this : name => policy.id }
+  value       = { for name, policy in aws_cloudwatch_log_resource_policy.this : name => policy.policy_document }
 }

--- a/modules/log-group/outputs.tf
+++ b/modules/log-group/outputs.tf
@@ -7,3 +7,8 @@ output "cloudwatch_log_group_arn" {
   description = "ARN of Cloudwatch log group"
   value       = element(concat(aws_cloudwatch_log_group.this.*.arn, [""]), 0)
 }
+
+output "cloudwatch_log_group_resource_policy_ids" {
+  description = "IDs of Cloudwatch Resource Policies"
+  value       = { for name, policy in aws_cloudwatch_log_resource_policy.this : name => policy.id }
+}

--- a/modules/log-group/variables.tf
+++ b/modules/log-group/variables.tf
@@ -33,3 +33,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "resource_policies" {
+  description = "The resource policies to attach to the Cloudwatch log group mapped name to document"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/log-group/variables.tf
+++ b/modules/log-group/variables.tf
@@ -40,8 +40,8 @@ variable "resource_policies" {
   default     = {}
 }
 
-variable "allowed_services" {
-  description = "The names of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier"
+variable "allowed_service_ids" {
+  description = "The IDs of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier"
   type        = set(string)
   default     = []
 }

--- a/modules/log-group/variables.tf
+++ b/modules/log-group/variables.tf
@@ -39,3 +39,9 @@ variable "resource_policies" {
   type        = map(string)
   default     = {}
 }
+
+variable "allowed_services" {
+  description = "The names of AWS services that should be allowed to publish logs to this log-group.  Names should be the identifier for the AWS service principal minus the `.amazonaws.com`. For example, elasticsearch would be `es`.  Each service will become one of the resource policies attached and will recieve a policy name equal to the service identifier"
+  type        = set(string)
+  default     = []
+}

--- a/modules/log-group/variables.tf
+++ b/modules/log-group/variables.tf
@@ -45,3 +45,13 @@ variable "allowed_services" {
   type        = set(string)
   default     = []
 }
+
+variable "allowed_service_actions" {
+  description = "The IAM actions to allow each service to perform"
+  type        = list(string)
+  default = [
+    "logs:CreateLogStream",
+    "logs:PutLogEvents",
+    "logs:PutLogEventsBatch",
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Log groups can have resource policies attached to them which are required when an AWS service is writing logs such as ElasticSearch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows resource policies to be passed to the log-group module which will create the attachments.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None, the variables are new and default to empty thus creating nothing when not passed.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have created a log-group example and created the resources in our environment.