### PR TITLE
feat: Allow overriding items for each control in `cis-alarms` module

### DIFF
--- a/examples/cis-alarms/README.md
+++ b/examples/cis-alarms/README.md
@@ -32,8 +32,10 @@ No providers.
 |------|--------|---------|
 | <a name="module_all_cis_alarms"></a> [all\_cis\_alarms](#module\_all\_cis\_alarms) | ../../modules/cis-alarms | n/a |
 | <a name="module_aws_sns_topic"></a> [aws\_sns\_topic](#module\_aws\_sns\_topic) | ../fixtures/aws_sns_topic | n/a |
+| <a name="module_control_overrides"></a> [control\_overrides](#module\_control\_overrides) | ../../modules/cis-alarms | n/a |
 | <a name="module_disabled_all_cis_alarms"></a> [disabled\_all\_cis\_alarms](#module\_disabled\_all\_cis\_alarms) | ../../modules/cis-alarms | n/a |
 | <a name="module_log"></a> [log](#module\_log) | ../fixtures/aws_cloudwatch_log_group | n/a |
+| <a name="module_second_aws_sns_topic"></a> [second\_aws\_sns\_topic](#module\_second\_aws\_sns\_topic) | ../fixtures/aws_sns_topic | n/a |
 
 ## Resources
 

--- a/modules/cis-alarms/README.md
+++ b/modules/cis-alarms/README.md
@@ -36,6 +36,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_actions_enabled"></a> [actions\_enabled](#input\_actions\_enabled) | Indicates whether or not actions should be executed during any changes to the alarm's state. | `bool` | `true` | no |
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | List of ARNs to put as Cloudwatch Alarms actions (eg, ARN of SNS topic) | `list(string)` | `[]` | no |
+| <a name="input_control_overrides"></a> [control\_overrides](#input\_control\_overrides) | A map of overrides to apply to each control | `any` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log metric filter and metric alarms | `bool` | `true` | no |
 | <a name="input_disabled_controls"></a> [disabled\_controls](#input\_disabled\_controls) | List of IDs of disabled CIS controls | `list(string)` | `[]` | no |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | The name of the log group to associate the metric filter with | `string` | `""` | no |

--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -79,7 +79,7 @@ locals {
   ###############
 
   prefix   = var.use_random_name_prefix ? "${random_pet.this[0].id}-" : var.name_prefix
-  controls = { for k, v in local.all_controls : k => merge(v, lookup(var.control_overrides, k, {})) if var.create && !contains(var.disabled_controls, k) }
+  controls = { for k, v in local.all_controls : k => merge(v, try(var.control_overrides[k], {})) if var.create && !contains(var.disabled_controls, k) }
 }
 
 resource "random_pet" "this" {

--- a/modules/cis-alarms/variables.tf
+++ b/modules/cis-alarms/variables.tf
@@ -16,6 +16,12 @@ variable "name_prefix" {
   default     = ""
 }
 
+variable "control_overrides" {
+  description = "A map of overrides to apply to each control"
+  default     = {}
+  type        = any
+}
+
 variable "disabled_controls" {
   description = "List of IDs of disabled CIS controls"
   type        = list(string)


### PR DESCRIPTION
## Description
With this it's possible to customize specific alarm controls, like using a
different pattern if needed or sending specific alarms to different topics.

The `for_each` condition has been changed and `var.create` is now applied when
generating `local.controls`. This is because Terraform complained that the
expression `var.create ? x : y` was returning different types for the true and
false conditions. By filtering controls early we sidestep the problem.

Fixed #35

## Motivation and Context
- SecurityHub sometimes requires very specific rules like the one in #35
- My particular use case is not triggering alarms on users logging in via SSO. Even if using the built-in SSO provider from amazon, you'll get Cloudtrail events with "MFAUsed: no" which will trigger that particular alarm

## Breaking Changes
Doesn't break current rulesets, only allows you to change them.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
