### PR TITLE
feat: Update CIS-Alarms for unauthorized API calls AWS Benchmark

### DIFF
--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -1,7 +1,7 @@
 locals {
   all_controls = {
     UnauthorizedAPICalls = {
-      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) && (($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") && ($.eventName!=\"HeadBucket\")) }"
+      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) }"
       description = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
     }
 


### PR DESCRIPTION
## Description
AWS CIS check remediation metric filter described in the official documentation ( https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html) is different from the metric filter written in this terraform module.  This metric filter difference is causing a false CIS check security hub. Currently, the security hub is marking the CIS check for unauthorized API call as "failed" reason is "Not valid metric filter found".

## Motivation and Context
This PR will fix the false security hub unauthorized API call CIS check failure.

## Breaking Changes
There are no breaking changes.

## How Has This Been Tested?
Tested in a development environment.
