### PR TITLE
feat: Updated UnauthorizedAPICalls pattern to pass CIS v1.2.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  TFLINT_VERSION: v0.44.1
 
 jobs:
   collectInputs:
@@ -46,6 +47,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
@@ -54,6 +56,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
@@ -75,5 +78,6 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           install-hcledit: true

--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -1,7 +1,7 @@
 locals {
   all_controls = {
     UnauthorizedAPICalls = {
-      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) && (($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") && ($.eventName!=\"HeadBucket\")) }"
+      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) }"
       description = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
According to the documentation of [CIS AWS Foundations Benchmark v1.2.0](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html) the pattern for UnauthorizedAPICalls should be `{($.errorCode="*UnauthorizedOperation") || ($.errorCode="AccessDenied*")}`. As of today it also validates the sourceIP and the eventName, leading to the check of CIS 3.1 to fail. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Merging this change will make the module compliant with the documentation of the [CIS AWS Foundations Benchmark v1.2.0](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes. Those users that still want to check for sourceIP and eventName can do so by utilising the control_overrides. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
