### PR TITLE
fix: Make unauthorized pattern match exact

### DIFF
--- a/modules/cis-alarms/main.tf
+++ b/modules/cis-alarms/main.tf
@@ -1,7 +1,7 @@
 locals {
   all_controls = {
     UnauthorizedAPICalls = {
-      pattern     = "{ (($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")) }"
+      pattern     = "{ ($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\") }"
       description = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
     }
 


### PR DESCRIPTION
## Description
Remove a parentes group from the UnauthorizedAPICalls check in the CSI framework.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So... After spending some time with the folks over at AWS support it turns out that the Security Hub checks for Metric filters in the CSI framework just check if the pattern is exactly what they have defined. No regex what so ever or validation of the pattern on sample data. So removing a parentes group to make it actually work...  

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
