### PR TITLE
feat: Add support for `period` in `metric_query_block`

### DIFF
--- a/examples/fixtures/aws_lambda_function/main.tf
+++ b/examples/fixtures/aws_lambda_function/main.tf
@@ -60,5 +60,5 @@ resource "aws_lambda_function" "this" {
   role             = aws_iam_role.lambda.arn
   handler          = "index.lambda_handler"
   source_code_hash = data.archive_file.lambda.output_base64sha256
-  runtime          = "python3.6"
+  runtime          = "python3.9"
 }

--- a/modules/metric-alarm/README.md
+++ b/modules/metric-alarm/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
 
 ## Modules
 

--- a/modules/metric-alarm/main.tf
+++ b/modules/metric-alarm/main.tf
@@ -36,6 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
       label       = lookup(metric_query.value, "label", null)
       return_data = lookup(metric_query.value, "return_data", null)
       expression  = lookup(metric_query.value, "expression", null)
+      period      = lookup(metric_query.value, "period", null)
 
       dynamic "metric" {
         for_each = lookup(metric_query.value, "metric", [])

--- a/modules/metric-alarm/versions.tf
+++ b/modules/metric-alarm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.59"
     }
   }
 }

--- a/modules/metric-alarms-by-multiple-dimensions/README.md
+++ b/modules/metric-alarms-by-multiple-dimensions/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.59 |
 
 ## Modules
 

--- a/modules/metric-alarms-by-multiple-dimensions/main.tf
+++ b/modules/metric-alarms-by-multiple-dimensions/main.tf
@@ -35,6 +35,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
       label       = lookup(metric_query.value, "label", null)
       return_data = lookup(metric_query.value, "return_data", null)
       expression  = lookup(metric_query.value, "expression", null)
+      period      = lookup(metric_query.value, "period", null)
 
       dynamic "metric" {
         for_each = lookup(metric_query.value, "metric", [])

--- a/modules/metric-alarms-by-multiple-dimensions/versions.tf
+++ b/modules/metric-alarms-by-multiple-dimensions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.59"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for `period` in `metric_query_block`. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/29896
Update example fixtures lambda runtime to 3.9 since 3.6 is no longer supported for creating or updating lambda functions. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
