### PR TITLE
fix: Fix example of alarm with anomaly detection

### DIFF
--- a/examples/lambda-metric-alarm/main.tf
+++ b/examples/lambda-metric-alarm/main.tf
@@ -119,10 +119,8 @@ module "alarm_anomaly" {
   metric_query = [{
     id = "ad1"
 
-    return_data = true
     expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
     label       = "Invocations (expected)"
-    return_data = "true"
     },
     {
       id = "m1"
@@ -138,7 +136,7 @@ module "alarm_anomaly" {
           FunctionName = module.aws_lambda_function2.lambda_function_name
         }
       }]
-      return_data = "true"
+      return_data = true
   }]
 
   alarm_actions = [module.aws_sns_topic.sns_topic_arn]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The example is invalid, from the documentation [return_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm#return_data-1) must be use only once by alarm. 

Note, the official documentation also have the same error in the example: https://github.com/hashicorp/terraform-provider-aws/pull/41780.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
