### PR TITLE
feat: Add `deletion_protection_enabled` to log-group module

### DIFF
--- a/modules/log-group/README.md
+++ b/modules/log-group/README.md
@@ -29,6 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create the Cloudwatch log group | `bool` | `true` | no |
+| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Whether to enable deletion protection for the log group. When enabled, the log group cannot be deleted | `bool` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting logs | `string` | `null` | no |
 | <a name="input_log_group_class"></a> [log\_group\_class](#input\_log\_group\_class) | Specified the log class of the log group. Possible values are: STANDARD or INFREQUENT\_ACCESS | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name for the log group | `string` | `null` | no |

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -1,11 +1,11 @@
 resource "aws_cloudwatch_log_group" "this" {
   count = var.create ? 1 : 0
 
-  name              = var.name
-  name_prefix       = var.name_prefix
-  retention_in_days = var.retention_in_days
-  kms_key_id        = var.kms_key_id
-  log_group_class   = var.log_group_class
+  name                        = var.name
+  name_prefix                 = var.name_prefix
+  retention_in_days           = var.retention_in_days
+  kms_key_id                  = var.kms_key_id
+  log_group_class             = var.log_group_class
   skip_destroy                = var.skip_destroy
   deletion_protection_enabled = var.deletion_protection_enabled
 

--- a/modules/log-group/main.tf
+++ b/modules/log-group/main.tf
@@ -6,7 +6,8 @@ resource "aws_cloudwatch_log_group" "this" {
   retention_in_days = var.retention_in_days
   kms_key_id        = var.kms_key_id
   log_group_class   = var.log_group_class
-  skip_destroy      = var.skip_destroy
+  skip_destroy                = var.skip_destroy
+  deletion_protection_enabled = var.deletion_protection_enabled
 
   tags = var.tags
 }

--- a/modules/log-group/variables.tf
+++ b/modules/log-group/variables.tf
@@ -45,6 +45,12 @@ variable "skip_destroy" {
   default     = null
 }
 
+variable "deletion_protection_enabled" {
+  description = "Whether to enable deletion protection for the log group. When enabled, the log group cannot be deleted"
+  type        = bool
+  default     = null
+}
+
 variable "tags" {
   description = "A map of tags to add to Cloudwatch log group"
   type        = map(string)

--- a/wrappers/log-group/main.tf
+++ b/wrappers/log-group/main.tf
@@ -3,12 +3,13 @@ module "wrapper" {
 
   for_each = var.items
 
-  create            = try(each.value.create, var.defaults.create, true)
-  kms_key_id        = try(each.value.kms_key_id, var.defaults.kms_key_id, null)
-  log_group_class   = try(each.value.log_group_class, var.defaults.log_group_class, null)
-  name              = try(each.value.name, var.defaults.name, null)
-  name_prefix       = try(each.value.name_prefix, var.defaults.name_prefix, null)
-  retention_in_days = try(each.value.retention_in_days, var.defaults.retention_in_days, null)
-  skip_destroy      = try(each.value.skip_destroy, var.defaults.skip_destroy, null)
-  tags              = try(each.value.tags, var.defaults.tags, {})
+  create                      = try(each.value.create, var.defaults.create, true)
+  deletion_protection_enabled = try(each.value.deletion_protection_enabled, var.defaults.deletion_protection_enabled, null)
+  kms_key_id                  = try(each.value.kms_key_id, var.defaults.kms_key_id, null)
+  log_group_class             = try(each.value.log_group_class, var.defaults.log_group_class, null)
+  name                        = try(each.value.name, var.defaults.name, null)
+  name_prefix                 = try(each.value.name_prefix, var.defaults.name_prefix, null)
+  retention_in_days           = try(each.value.retention_in_days, var.defaults.retention_in_days, null)
+  skip_destroy                = try(each.value.skip_destroy, var.defaults.skip_destroy, null)
+  tags                        = try(each.value.tags, var.defaults.tags, {})
 }


### PR DESCRIPTION
## Description

Expose the `deletion_protection_enabled` attribute in the `modules/log-group` module, allowing users to enable CloudWatch Logs deletion protection.

This attribute is supported by the underlying `aws_cloudwatch_log_group` resource since AWS provider v6.25.

Closes #82

## Changes

- Add `deletion_protection_enabled` variable (`bool`, default `null`) to `modules/log-group`
- Pass the variable through to the `aws_cloudwatch_log_group` resource
- Update README inputs table

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request