### PR TITLE
chore(metric-alarm): Modernize attribute access

### DIFF
--- a/modules/metric-alarm/README.md
+++ b/modules/metric-alarm/README.md
@@ -4,14 +4,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
 
 ## Modules
@@ -21,13 +21,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_metric_alarm.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_actions_enabled"></a> [actions\_enabled](#input\_actions\_enabled) | Indicates whether or not actions should be executed during any changes to the alarm's state. Defaults to true. | `bool` | `true` | no |
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | The list of actions to execute when this alarm transitions into an ALARM state from any other state. Each action is specified as an Amazon Resource Name (ARN). | `list(string)` | `null` | no |
 | <a name="input_alarm_description"></a> [alarm\_description](#input\_alarm\_description) | The description for the alarm. | `string` | `null` | no |
@@ -55,7 +55,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cloudwatch_metric_alarm_arn"></a> [cloudwatch\_metric\_alarm\_arn](#output\_cloudwatch\_metric\_alarm\_arn) | The ARN of the Cloudwatch metric alarm. |
 | <a name="output_cloudwatch_metric_alarm_id"></a> [cloudwatch\_metric\_alarm\_id](#output\_cloudwatch\_metric\_alarm\_id) | The ID of the Cloudwatch metric alarm. |
 <!-- END_TF_DOCS -->

--- a/modules/metric-alarm/main.tf
+++ b/modules/metric-alarm/main.tf
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   dynamic "metric_query" {
     for_each = var.metric_query
     content {
-      id          = lookup(metric_query.value, "id")
+      id          = metric_query.value["id"]
       account_id  = lookup(metric_query.value, "account_id", null)
       label       = lookup(metric_query.value, "label", null)
       return_data = lookup(metric_query.value, "return_data", null)
@@ -41,10 +41,10 @@ resource "aws_cloudwatch_metric_alarm" "this" {
       dynamic "metric" {
         for_each = lookup(metric_query.value, "metric", [])
         content {
-          metric_name = lookup(metric.value, "metric_name")
-          namespace   = lookup(metric.value, "namespace")
-          period      = lookup(metric.value, "period")
-          stat        = lookup(metric.value, "stat")
+          metric_name = metric.value["metric_name"]
+          namespace   = metric.value["namespace"]
+          period      = metric.value["period"]
+          stat        = metric.value["stat"]
           unit        = lookup(metric.value, "unit", null)
           dimensions  = lookup(metric.value, "dimensions", null)
         }

--- a/modules/metric-alarm/outputs.tf
+++ b/modules/metric-alarm/outputs.tf
@@ -1,9 +1,9 @@
 output "cloudwatch_metric_alarm_arn" {
   description = "The ARN of the Cloudwatch metric alarm."
-  value       = try(aws_cloudwatch_metric_alarm.this[0].arn, "")
+  value       = one(aws_cloudwatch_metric_alarm.this[*].arn)
 }
 
 output "cloudwatch_metric_alarm_id" {
   description = "The ID of the Cloudwatch metric alarm."
-  value       = try(aws_cloudwatch_metric_alarm.this[0].id, "")
+  value       = one(aws_cloudwatch_metric_alarm.this[*].id)
 }


### PR DESCRIPTION
## Description

-Replace legacy `lookup()` calls with direct map indexing for required attributes inside the `metric_query` and metric dynamic blocks. Replace `try(...[0])` outputs with `one(aws_cloudwatch_metric_alarm.this[*].arn/id)` to return the single value from the resource collection.

## Motivation and Context

- @bryantbiggs Not sure if you're accepting PRs on these modules anymore, but wanted to contribute some modernizations that we are using in our environments

## Breaking Changes

- N/A

## How Has This Been Tested?
- [X] This is actively being used in our environment
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
